### PR TITLE
[docs] modify links for readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[English](README.md)| [简体中文](README_ch.md)
+English | [简体中文](README_ch.md)
 
 </div>
 
@@ -34,7 +34,7 @@ https://user-images.githubusercontent.com/57089550/202428765-121ec2d8-2ecc-4b2e-
 - [stereo depth estimation](./Paddlestereo/README.md)
 
 
-<a name="效果展示"></a>
+<a name="Visualization"></a>
 
 ## 👀 Visualization
 

--- a/README_ch.md
+++ b/README_ch.md
@@ -3,7 +3,7 @@
 
 <div align="center">
 
-[English](README.md)| [简体中文](README_ch.md)
+[English](README.md)| 简体中文
 
 </div>
 


### PR DESCRIPTION
去掉当前语种的链接，当前页可以不显示跳转到自己，只允许到另一语种的文档。